### PR TITLE
feat: 記事一覧ページのタイトルを押下して記事詳細とタイトルを閲覧できるようにした。

### DIFF
--- a/app/.server/cms/post/index.ts
+++ b/app/.server/cms/post/index.ts
@@ -2,7 +2,7 @@ import { endpoints } from '../endpoints'
 
 import type { Content } from '../../../types'
 import type { ClientType } from '../client'
-import type { MicroCMSQueries } from 'microcms-js-sdk'
+import type { MicroCMSListResponse, MicroCMSQueries } from 'microcms-js-sdk'
 
 type PickMicroCMSQueries = Pick<MicroCMSQueries, 'offset' | 'limit' | 'filters'>
 
@@ -27,3 +27,18 @@ export const getPosts = async (
 
   return data
 }
+
+/**
+ * 特定の記事を取得
+ * @param contentId 記事ページのスラッグ
+ */
+export const findPost = async (client: ClientType, contentId: string) => {
+  const data = await client.get<Content>({
+    endpoint: endpoints.blogs,
+    contentId,
+  })
+
+  return data
+}
+
+export { MicroCMSListResponse }

--- a/app/.server/loaders/index.ts
+++ b/app/.server/loaders/index.ts
@@ -1,2 +1,3 @@
 export * from './indexLoader'
+export * from './postDetailLoader'
 export * from './rootLoader'

--- a/app/.server/loaders/indexLoader/index.ts
+++ b/app/.server/loaders/indexLoader/index.ts
@@ -2,11 +2,17 @@ import { json } from '@remix-run/cloudflare'
 
 import { client, getPosts } from '../../cms'
 
-import type { LoaderFunctionArgs } from '@remix-run/cloudflare'
+import type { Content } from '../../../types'
+import type { MicroCMSListResponse } from '../../cms'
+import type { LoaderFunctionArgs, TypedResponse } from '@remix-run/cloudflare'
 
-export const indexLoader = async ({ context }: LoaderFunctionArgs) => {
+export const indexLoader = async ({
+  context,
+}: LoaderFunctionArgs): Promise<
+  TypedResponse<MicroCMSListResponse<Content>>
+> => {
   const { CMS_API_KEY } = context.cloudflare.env
-  const cmsClient = client(CMS_API_KEY)
-  const posts = await getPosts(cmsClient)
+  const posts = await getPosts(client(CMS_API_KEY))
+
   return json({ ...posts })
 }

--- a/app/.server/loaders/postDetailLoader/index.ts
+++ b/app/.server/loaders/postDetailLoader/index.ts
@@ -1,0 +1,24 @@
+import { json } from '@remix-run/cloudflare'
+
+import { client, findPost } from '../../cms'
+
+import type { Content } from '../../../types'
+import type { LoaderFunctionArgs, TypedResponse } from '@remix-run/cloudflare'
+
+export const postDetailLoader = async ({
+  params,
+  context,
+}: LoaderFunctionArgs): Promise<TypedResponse<Content>> => {
+  // https://remix.run/docs/en/main/guides/not-found#how-to-send-a-404
+  if (!params.contentId) {
+    throw new Response(null, {
+      status: 404,
+      statusText: 'Not Found',
+    })
+  }
+
+  const { CMS_API_KEY } = context.cloudflare.env
+  const post = await findPost(client(CMS_API_KEY), params.contentId)
+
+  return json({ ...post })
+}

--- a/app/features/articles/index.ts
+++ b/app/features/articles/index.ts
@@ -1,0 +1,1 @@
+export * from './page'

--- a/app/features/articles/page/ArticleDetailPage.tsx
+++ b/app/features/articles/page/ArticleDetailPage.tsx
@@ -1,13 +1,13 @@
-import { Heading } from '../../components'
+import { Heading } from '../../../components'
 
-import type { Content } from '../../types'
+import type { Content } from '../../../types'
 import type { SerializeFrom } from '@remix-run/cloudflare'
 
 type Props = {
   content: SerializeFrom<Content>
 }
 
-export const PostDetailPage = ({ content }: Props) => {
+export const ArticleDetailPage = ({ content }: Props) => {
   return (
     <div>
       <Heading as="h1">{content.title}</Heading>

--- a/app/features/articles/page/ArticleListPage.tsx
+++ b/app/features/articles/page/ArticleListPage.tsx
@@ -1,12 +1,12 @@
-import { Heading, Link } from '../../components'
+import { Heading, Link } from '../../../components'
 
-import type { Content } from '../../types'
+import type { Content } from '../../../types'
 
 type Props = {
   contents: Content[]
 }
 
-export const TopPage = ({ contents }: Props) => {
+export const ArticleListPage = ({ contents }: Props) => {
   return (
     <div className="p-4 font-sans">
       {contents.map((content) => (

--- a/app/features/articles/page/index.ts
+++ b/app/features/articles/page/index.ts
@@ -1,0 +1,2 @@
+export * from './ArticleDetailPage'
+export * from './ArticleListPage'

--- a/app/features/index.ts
+++ b/app/features/index.ts
@@ -1,0 +1,1 @@
+export * from './articles'

--- a/app/pages/index.ts
+++ b/app/pages/index.ts
@@ -1,1 +1,2 @@
+export * from './postDetail'
 export * from './top'

--- a/app/pages/index.ts
+++ b/app/pages/index.ts
@@ -1,2 +1,0 @@
-export * from './postDetail'
-export * from './top'

--- a/app/pages/postDetail/index.tsx
+++ b/app/pages/postDetail/index.tsx
@@ -1,0 +1,17 @@
+import { Heading } from '../../components'
+
+import type { Content } from '../../types'
+import type { SerializeFrom } from '@remix-run/cloudflare'
+
+type Props = {
+  content: SerializeFrom<Content>
+}
+
+export const PostDetailPage = ({ content }: Props) => {
+  return (
+    <div>
+      <Heading as="h1">{content.title}</Heading>
+      <div dangerouslySetInnerHTML={{ __html: content.body }} />
+    </div>
+  )
+}

--- a/app/pages/top/index.tsx
+++ b/app/pages/top/index.tsx
@@ -1,3 +1,5 @@
+import { Heading, Link } from '../../components'
+
 import type { Content } from '../../types'
 
 type Props = {
@@ -9,7 +11,11 @@ export const TopPage = ({ contents }: Props) => {
     <div className="p-4 font-sans">
       {contents.map((content) => (
         <div key={content.id}>
-          <h2>{content.title}</h2>
+          <Link to={`/articles/${content.id}`}>
+            <Heading as="h2" size="lg">
+              {content.title}
+            </Heading>
+          </Link>
         </div>
       ))}
     </div>

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,7 +1,7 @@
 import { useLoaderData } from '@remix-run/react'
 
 import { indexLoader as loader } from '../.server'
-import { TopPage } from '../pages'
+import { ArticleListPage } from '../features'
 
 import type { HeadersFunction } from '@remix-run/cloudflare'
 
@@ -20,5 +20,5 @@ export { loader }
 
 export default function Index() {
   const { contents } = useLoaderData<typeof loader>()
-  return <TopPage contents={contents} />
+  return <ArticleListPage contents={contents} />
 }

--- a/app/routes/articles.$contentId.tsx
+++ b/app/routes/articles.$contentId.tsx
@@ -1,0 +1,25 @@
+import { useLoaderData } from '@remix-run/react'
+
+import { postDetailLoader as loader } from '../.server'
+import { PostDetailPage } from '../pages'
+
+import type { HeadersFunction } from '@remix-run/cloudflare'
+
+export const headers: HeadersFunction = () => {
+  return {
+    // TODO: キャッシュ戦略後でちゃんと考える
+    // - レスポンスは7日間（604800 秒間）は新鮮。
+    // - 7日間経過したら、そこから 360s は、古いキャッシュを参照するが、バックグラウンドでfetchを行い、キャッシュを更新して、サーバから新しいリソースを取得できたら、キャッシュを更新する。
+    // - 7日を過ぎると古くなるが、サーバーがエラーでレスポンスを返した場合はさらに1日（86400 秒間）利用できる。
+    'Cache-Control':
+      'max-age=0, s-maxage=604800, stale-while-revalidate=360, stale-if-error=86400',
+  }
+}
+
+export { loader }
+
+export default function PostDetail() {
+  const content = useLoaderData<typeof loader>()
+  content.category_field
+  return <PostDetailPage content={content} />
+}

--- a/app/routes/articles.$contentId.tsx
+++ b/app/routes/articles.$contentId.tsx
@@ -1,7 +1,7 @@
 import { useLoaderData } from '@remix-run/react'
 
 import { postDetailLoader as loader } from '../.server'
-import { PostDetailPage } from '../pages'
+import { ArticleDetailPage } from '../features'
 
 import type { HeadersFunction } from '@remix-run/cloudflare'
 
@@ -21,5 +21,5 @@ export { loader }
 export default function PostDetail() {
   const content = useLoaderData<typeof loader>()
   content.category_field
-  return <PostDetailPage content={content} />
+  return <ArticleDetailPage content={content} />
 }


### PR DESCRIPTION
- 記事一覧ページのタイトルを押下して記事詳細とタイトルを閲覧できるようにした。
- ドメイン知識を持ったコンポーネント置き場をefaturesに変更した。